### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/LibraryMake.pm6
+++ b/lib/LibraryMake.pm6
@@ -1,5 +1,5 @@
 #| An attempt to simplify building native code for a perl6 module.
-module LibraryMake;
+unit module LibraryMake;
 
 =begin pod
 This is effectively a small configure script for a Makefile. It will allow you to


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.