### PR TITLE
fix failing coverage test

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,5 +1,6 @@
 use v6;
 use Test;
+use lib 'lib';
 use Shell::Command;
 use Pod::Coverage;
 
@@ -23,6 +24,6 @@ ok (("test"~%vars<EXE>).IO ~~ :f), "Binary was created";
 
 ok qqx/.{$*SPEC.dir-sep}test%vars<EXE>/ ~~ /^Hello ' ' world\!\n$/, "Binary runs!";
 
-my $p = Pod::Coverage.new;
+my $p = Pod::Coverage::Full.new;
 $p.parse(LibraryMake);
 ok !$p.are-missing, 'Everything is documented';


### PR DESCRIPTION
Hi,
Panda is no longer able to install LibraryMake due to a failing test:
```
==> Fetching LibraryMake
==> Building LibraryMake
==> Testing LibraryMake
Method 'parse' not found for invocant of class 'Pod::Coverage'
  in block <unit> at t/01-basic.t:27

# Looks like you planned 8 tests, but ran 7
t/01-basic.t ..
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 1/8 subtests

Test Summary Report
-------------------
t/01-basic.t (Wstat: 65280 Tests: 7 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 8 tests but ran 7.
Files=1, Tests=7,  3 wallclock secs ( 0.03 usr  0.00 sys +  3.09 cusr  0.09 csys =  3.21 CPU)
Result: FAIL
```
This is due to Pod::Coverage moving parse to Pod::Coverage::Full.
This patch fixes that. 