### PR TITLE
don't test %LIBS

### DIFF
--- a/t/Makefile.in
+++ b/t/Makefile.in
@@ -1,7 +1,7 @@
 all: %DESTDIR%/test%EXE%
 
 %DESTDIR%/test%EXE%: test%O%
-	%LD% %LDFLAGS% %LIBS% %LDOUT%%DESTDIR%/test%EXE% test%O%
+	%LD% %LDFLAGS% %LDOUT%%DESTDIR%/test%EXE% test%O%
 
 test%O%: test.c
 	%CC% -c %CCFLAGS% %CCOUT%test%O% test.c


### PR DESCRIPTION
this should fix #28 which appears to be caused by some of the libraries
used to link Rakudo not being generally available.

I don't use %LIBS ,or at least tend to override it (LibXML, Base64::Native,
...). I don't think its widely used in general.