### PR TITLE
Change author filed to auth

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
     "perl" : "6.*",
     "name" : "LibraryMake",
     "version" : "1.0.0",
-    "author" : "github:retupmoca",
+    "auth" : "github:retupmoca",
     "description" : "An attempt to simplify native compilation",
     "depends" : [ "Shell::Command", "File::Which" ],
     "provides" : {


### PR DESCRIPTION
This should be `auth`  instead of `author`, the `auth` field is used to identify the long name of the module (eg. `MyModule:auth<name>`).